### PR TITLE
Bug 520 - Feature request: Show DUID of DHCPv6 client request in log

### DIFF
--- a/server/db.c
+++ b/server/db.c
@@ -584,6 +584,11 @@ write_ia(const struct ia_xx *ia) {
 			    binding_state) < 0) {
 			goto error_exit;
 		}
+		if (iasubopt->ipv6_pool && iasubopt->ipv6_pool->shared_network &&
+			    iasubopt->ipv6_pool->shared_network->name) {
+			fprintf(db_file, "#shared-network: %s\n", 
+			    iasubopt->ipv6_pool->shared_network->name);
+		}
 		if (fprintf(db_file, "    preferred-life %u;\n",
 			    (unsigned)iasubopt->prefer) < 0) {
 			goto error_exit;


### PR DESCRIPTION
Changes in dhcpv6 leases database to fix problems described in Bug 520 (prints shared-network name same way as it was done for ipv4).
